### PR TITLE
feat: add highlight box

### DIFF
--- a/packages/highlight-box/index.html
+++ b/packages/highlight-box/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <meta name="description" content="" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://assets.finn.no/pkg/@fabric-ds/css/v0/fabric.min.css"
+    />
+    <title>Highlight Box Element</title>
+  </head>
+  <body>
+    <f-docs-highlight-box></f-docs-highlight-box>
+    <!-- Link script files here -->
+    <script src="index.js"></script>
+  </body>
+</html>

--- a/packages/highlight-box/index.js
+++ b/packages/highlight-box/index.js
@@ -1,0 +1,27 @@
+class FabricDocsHighlightBox extends HTMLElement {
+  constructor() {
+    super();
+
+    const fabricStylesTemplate = document.createElement('template');
+    fabricStylesTemplate.innerHTML = `
+      <style>:host { display: block; }</style>
+      <link
+          rel="stylesheet"
+          type="text/css"
+          href="https://assets.finn.no/pkg/@fabric-ds/css/v0/fabric.min.css"
+      />
+      <div class="bg-yellow-100 rounded-8 p-24 mb-24">
+        <h3 class="h4">About Fabric Beta v1.0</h3>
+        <p class="pb-0">Fabric is currently in Beta phase. We’re working hard to get things running smoothly and can’t do it without your help. Head to the <a href="https://sch-chat.slack.com/archives/C01GYKPJVFT">#finn-fabric</a> channel on Slack to share your feedback.</p>
+      </div>
+    `;
+
+    this.attachShadow({ mode: 'open' }).appendChild(
+      fabricStylesTemplate.content
+    );
+  }
+}
+
+if (!customElements.get('f-docs-highlight-box')) {
+  customElements.define('f-docs-highlight-box', FabricDocsHighlightBox);
+}

--- a/packages/highlight-box/index.js
+++ b/packages/highlight-box/index.js
@@ -13,6 +13,7 @@ class FabricDocsHighlightBox extends HTMLElement {
       <div class="bg-yellow-100 rounded-8 p-24 mb-24">
         <h3 class="h4">About Fabric Beta v1.0</h3>
         <p class="pb-0">Fabric is currently in Beta phase. We’re working hard to get things running smoothly and can’t do it without your help. Head to the <a href="https://sch-chat.slack.com/archives/C01GYKPJVFT">#finn-fabric</a> channel on Slack to share your feedback.</p>
+        <div class="mb-8"><a href="https://sch-chat.slack.com/archives/C01GYKPJVFT" class="button button--secondary">Post feedback on Slack</a></div>
       </div>
     `;
 

--- a/packages/highlight-box/package.json
+++ b/packages/highlight-box/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@fabric-ds/docs-highlight-box",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fabric-ds/common.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/fabric-ds/common/issues"
+  },
+  "homepage": "https://github.com/fabric-ds/common#readme"
+}


### PR DESCRIPTION
Adds the highlight box as a custom element to be shared across the various repos

<img width="896" alt="Screenshot 2021-10-01 at 10 54 34" src="https://user-images.githubusercontent.com/1177098/135593204-690d34f3-8594-4e1a-ae17-9033d88e43f6.png">
