### PR TITLE
Add markdown styling to template

### DIFF
--- a/packages/template/index.js
+++ b/packages/template/index.js
@@ -44,6 +44,19 @@ class FabricDocsTemplate extends HTMLElement {
             background: linear-gradient(94.46deg, #0D55C8 3.76%, #1593E9 99.18%);
             padding: 60px 0px;
         }
+        .mdx code {
+          padding: 0.2em 0.4em;
+          margin: 0;
+          font-size: 80% !important;
+          background-color: rgba(175, 184, 193, 0.2);
+          border-radius: 6px;
+        }
+        .mdx .example {
+          padding: 30px;
+          border: 3px solid rgb(246, 248, 250);
+          margin-bottom: 16px;
+          margin-top: -20px;
+        }
       </style>
       <f-docs-navigation></f-docs-navigation>
       <main class="doc-grid min-h-screen">
@@ -59,7 +72,7 @@ class FabricDocsTemplate extends HTMLElement {
           }
           ${
             !!document.querySelector(['[slot="content"]'])
-              ? `<div class="mx-auto p-12 md:p-32" style="max-width:1024px">
+              ? `<div class="mdx mx-auto p-12 md:p-32" style="max-width:1024px">
                   <slot name="content"></slot>
                   ${
                     document.querySelector('[data-for="footer"]')


### PR DESCRIPTION
Going to test and see if this applies the appropriate markdown styling when markdown is slotted into the shadow dom. If it doesn't work, I'll revert the changes.